### PR TITLE
support for much better custom component usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
-
+.idea
 # compiled output
 /dist
 /tmp

--- a/addon/components/validated-input/template.hbs
+++ b/addon/components/validated-input/template.hbs
@@ -2,52 +2,61 @@
   {{label}}{{#if required}} *{{/if}}
 </label>
 
-{{#if (eq type "select")}}
-  {{one-way-select
-    value            = (get model name)
-    options          = options
-    optionLabelPath  = optionLabelPath
-    optionValuePath  = optionValuePath
-    optionTargetPath = optionTargetPath
-    name             = name
-    class            = config.css.control
-    update           = (action "update")
-    focusOut         = (action "setDirty")
-    includeBlank     = includeBlank
-    disabled         = disabled
-    multiple         = multiple
-    }}
-
-{{else if (eq type "radioGroup")}}
-
-  {{#each options as |option|}}
-    <div class="radio">
-      <label>
-      {{one-way-radio
-        value    = (get model name)
-        option   = option.key
-        name     = name
-        update   = (action "update")
-        focusOut = (action "setDirty")
-        disabled = disabled
-        }}
-        {{option.label}}</label>
-    </div>
-  {{/each}}
-
+{{#if hasBlock}}
+  {{yield (hash value=(get model name)
+            controlClass=config.css.control
+            update=(action 'update')
+            setDirty=(action 'setDirty')
+            model=model
+            name=name)}}
 {{else}}
-
-  {{component (concat "one-way-" type)
-    value       = (get model name)
-    options     = options
-    name        = name
-    class       = config.css.control
-    update      = (action "update")
-    focusOut    = (action "setDirty")
-    placeholder = placeholder
-    disabled    = disabled
+  {{#if (eq type "select")}}
+    {{one-way-select
+      value            = (get model name)
+      options          = options
+      optionLabelPath  = optionLabelPath
+      optionValuePath  = optionValuePath
+      optionTargetPath = optionTargetPath
+      name             = name
+      class            = config.css.control
+      update           = (action "update")
+      focusOut         = (action "setDirty")
+      includeBlank     = includeBlank
+      disabled         = disabled
+      multiple         = multiple
     }}
 
+  {{else if (eq type "radioGroup")}}
+
+    {{#each options as |option|}}
+      <div class="radio">
+        <label>
+          {{one-way-radio
+            value    = (get model name)
+            option   = option.key
+            name     = name
+            update   = (action "update")
+            focusOut = (action "setDirty")
+            disabled = disabled
+          }}
+          {{option.label}}</label>
+      </div>
+    {{/each}}
+
+  {{else}}
+
+    {{component (concat "one-way-" type)
+                value       = (get model name)
+                options     = options
+                name        = name
+                class       = config.css.control
+                update      = (action "update")
+                focusOut    = (action "setDirty")
+                placeholder = placeholder
+                disabled    = disabled
+    }}
+
+  {{/if}}
 {{/if}}
 
 {{#if help}}

--- a/tests/dummy/app/components/color-component.js
+++ b/tests/dummy/app/components/color-component.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: '',
+  colorStyle: Ember.computed('color.color', function () {
+    let color = this.get('color.color');
+    return Ember.String.htmlSafe('background-color:' + color + ";");
+  }),
+  actions: {
+    onclick() {
+      this.get('colorSelected')(this.get('color'));
+    }
+  }
+});

--- a/tests/dummy/app/components/favorite-colors-component.js
+++ b/tests/dummy/app/components/favorite-colors-component.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+
+  hasSelected: Ember.computed.notEmpty('selected'),
+  isShowingColors:false,
+
+  actions: {
+    onColorSelected(color) {
+      this.set('selected', color);
+      this.toggleProperty('isShowingColors');
+      this.get('onupdate')(color.name);
+    },
+
+    toggle() {
+      this.toggleProperty('isShowingColors');
+    },
+
+    onhover() {
+      this.get('onhover')();
+    },
+
+    clearSelection() {
+      this.set('selected', null);
+      this.get('onupdate')(null);
+    }
+  }
+});

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -5,6 +5,7 @@ import { task, timeout } from 'ember-concurrency';
 export default Ember.Controller.extend({
   UserValidations,
 
+  colors:[{name:'Red', color:'red'}, {name:'Green', color:'green'}, {name: 'Blue', color:'blue'}],
   countries: ['United States', 'United Kingdom', 'Switzerland', 'Other'],
   genders: [{
     key: 'm',

--- a/tests/dummy/app/templates/components/color-component.hbs
+++ b/tests/dummy/app/templates/components/color-component.hbs
@@ -1,0 +1,3 @@
+<div style="{{colorStyle}}" onclick={{action 'onclick'}}>
+  {{color.name}}
+</div>

--- a/tests/dummy/app/templates/components/favorite-colors-component.hbs
+++ b/tests/dummy/app/templates/components/favorite-colors-component.hbs
@@ -1,0 +1,13 @@
+<div onclick={{action 'toggle'}} onmouseover={{action 'onhover'}}>
+  {{#if hasSelected}}
+    {{selected.name}} <button onclick={{action 'clearSelection'}}>Clear Selection</button>
+  {{else}}
+    Click to choose your favorite color!
+  {{/if}}
+</div>
+
+{{#if isShowingColors}}
+  {{#each colors as |color|}}
+    {{color-component color=color colorSelected=(action 'onColorSelected')}}
+  {{/each}}
+{{/if}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -20,4 +20,12 @@
 
   {{f.input type="radioGroup" label="Gender" name="gender" options=genders}}
 
+
+  {{#f.input label="Favorite Color" name="color" as |fi|}}
+    {{favorite-colors-component colors=colors onupdate=fi.update onhover=fi.setDirty}}
+  {{/f.input}}
+
+  {{#f.input label="Accept the Terms" name="accepTheTerms" as |fi|}}
+    <input type="checkbox" onfocus={{fi.setDirty}} onchange={{action fi.update value='target.checked'}}>
+  {{/f.input}}
 {{/validated-form}}

--- a/tests/dummy/app/validations/user.js
+++ b/tests/dummy/app/validations/user.js
@@ -4,6 +4,21 @@ import {
 } from 'ember-changeset-validations/validators';
 
 
+function validateTerm() {
+  return (key, newValue) => {
+    // validation logic
+    // return `true` if valid || error message string if invalid
+    let result = newValue === true;
+
+    if (!result) {
+      return "Terms must be accepted!";
+    }
+
+    return true;
+  };
+}
+
+
 export default {
   firstName: [
     validatePresence(true),
@@ -15,5 +30,7 @@ export default {
   ],
   aboutMe: [ validateLength({allowBlank: true, max: 200}) ],
   country: [ validatePresence(true) ],
-  gender: [ validatePresence(true) ]
+  gender: [ validatePresence(true) ],
+  accepTheTerms: [ validateTerm() ],
+  color: [validatePresence(true)]
 };


### PR DESCRIPTION
There is a stackoverflow [question](http://stackoverflow.com/questions/42921997/using-ember-with-maskedinput-and-validated-form) regarding your addon. The developer there is willing to add a masked-input into your add-on. However; as far as I can see your support for custom components need a little bit of enhancement. Hence I have already created an [issue](https://github.com/adfinis-sygroup/ember-validated-form/issues/16) for what I mean. This is the pull request regarding that issue. I have already changed `validated-input` to be used in block-form. I also included two custom components (a custom color pick component and a checkbox) usage in block-form so as to demonstrate what I mean. If you accept the pull request I can also improve the documentation regarding the usage of custom component if you like. best regards.
