### PR TITLE
Upgrade to ember 2.12.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-validated-form",
   "dependencies": {
-    "ember": "~2.10.0",
+    "ember": "~2.12.0",
     "ember-cli-shims": "0.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "ember-changeset": "1.2.0",
-    "ember-cli-htmlbars": "1.1.1",
+    "ember-cli-babel": "^5.1.7",
+    "ember-cli-htmlbars": "^1.0.10",
     "ember-truth-helpers": "1.2.0",
     "ember-one-way-controls": "1.1.2",
     "ember-changeset-validations": "1.2.4"
@@ -36,10 +37,10 @@
     "ember-ajax": "^2.4.1",
     "ember-cli": "2.10.0",
     "ember-cli-app-version": "^2.0.0",
-    "ember-cli-babel": "^5.1.7",
+
+    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-github-pages": "0.1.2",
-    "ember-cli-htmlbars-inline-precompile": "0.3.6",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^3.0.1",


### PR DESCRIPTION
Upgraded an existing project from ember 2.10.0 to 2.12.0, due to https://github.com/cibernox/ember-power-select/issues/877 .

Having done the upgrade, on ember build, see a warning that ember-cli-babel, plus ember-validated-form addons should be under dependencies, not devDependencies.

Pull request is the result of upgrading the package to 2.12.0, and making the changes recommended by the warning.

Think the warning is caused by a change to ember-cli-babel at ember version 2.12.0.

Tests pass, demo builds and runs as previously.