### PR TITLE
Required (star) as an form field flag

### DIFF
--- a/addon/components/validated-input/component.js
+++ b/addon/components/validated-input/component.js
@@ -39,14 +39,6 @@ export default Ember.Component.extend({
     return !this.get('isValid') && (this.get('dirty') || this.get('submitted'));
   }),
 
-  init() {
-    this._super(...arguments);
-    // mark field as required if validation errors are present during init.
-    if (this.get(`model.error.${this.get('name')}.validation`)) {
-      this.set('required', true);
-    }
-  },
-
   actions: {
     setDirty() {
       this.set('dirty', true);

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -3,8 +3,8 @@
   model     = (changeset model UserValidations)
   as |f|}}
 
-  {{f.input label="First name" name="firstName"}}
-  {{f.input label="Last name" name="lastName"}}
+  {{f.input label="First name" name="firstName" required=true}}
+  {{f.input label="Last name" name="lastName" required=true}}
 
   {{f.input type="textarea" label="About me" name="aboutMe" help="Example help text"}}
 
@@ -14,11 +14,12 @@
     name         = "country"
     options      = countries
     includeBlank = "Please choose..."
+    required     = true
     }}
 
-  {{f.input type="radioGroup" label="Gender" name="gender" options=genders}}
+  {{f.input type="radioGroup" label="Gender" name="gender" options=genders required=true}}
 
-  {{#f.input label="Favorite Color" name="color" as |fi|}}
+  {{#f.input label="Favorite Color" name="color" required=true as |fi|}}
     {{favorite-colors-component colors=colors onupdate=fi.update onhover=fi.setDirty}}
   {{/f.input}}
 


### PR DESCRIPTION
Define on the form field if it should show a required star * or not. 
This does not overwrite other validation settings from the field.