### PR TITLE
Support block form usage of radioGroups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 npm-debug.log*
 testem.log
 *.swp
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -250,14 +250,16 @@ shapes: [{
 
 ```javascript
 // in your locale file
-Translations = {
-  some:
-    scope:
-      shapes: 'les formes'
-      triangle: 'un triangle'
-      square: 'un carré'
-      circle: 'un cercle'
-}
+export default {
+  'some': {
+    'scope': {
+      'shapes': 'les formes',
+      'triangle': 'un triangle',
+      'square': 'un carré',
+      'circle': 'un cercle'
+    }
+  }
+};
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -209,19 +209,57 @@ This component renders a [{{one-way-checkbox}}](https://github.com/DockYard/embe
 This component renders a list of [{{one-way-radio}}](https://github.com/DockYard/ember-one-way-controls/blob/master/docs/one-way-radio.md) components.
 
 ```Handlebars
-{{f.input type="radioGroup" label="Gender" name="gender" options=genders}}
+{{f.input type="radioGroup" label="Shapes" name="shapes" options=shapes}}
 ```
 
 ```javascript
 // in your controller
-genders: [{
-  key: 'm',
-  label: 'Male'
+shapes: [{
+  key: 't',
+  label: 'Triangle'
 }, {
-  key: 'f',
-  label: 'Female'
+  key: 's',
+  label: 'Square'
+}, {
+  key: 'c',
+  label: 'Circle'
 }],
 ```
+
+If you want to customize the markup for each radio-button's label, you can invoke this component using block form. This is helpful if you need to localize your labels using something like [ember-i18n](https://github.com/jamesarosen/ember-i18n).
+
+```Handlebars
+{{#f.input type="radioGroup" label=(t 'some.scope.shapes') name="shapes" options=shapes}}
+  {{t option.label}}
+{{/f.input}}
+```
+
+```javascript
+// in your controller
+shapes: [{
+  key: 't',
+  label: 'some.scope.triangle'
+}, {
+  key: 's',
+  label: 'some.scope.square'
+}, {
+  key: 'c',
+  label: 'some.scope.circle'
+}],
+```
+
+```javascript
+// in your locale file
+Translations = {
+  some:
+    scope:
+      shapes: 'les formes'
+      triangle: 'un triangle'
+      square: 'un carré'
+      circle: 'un cercle'
+}
+```
+
 
 ### Custom input elements
 

--- a/addon/components/validated-input/template.hbs
+++ b/addon/components/validated-input/template.hbs
@@ -7,13 +7,32 @@
 {{/if}}
 
 {{#if hasBlock}}
+  
+  {{#if (not-eq type "radioGroup")}}
+    {{yield (hash value=(or value (get model name))
+      controlClass=config.css.control
+      update=(action 'update')
+      setDirty=(action 'setDirty')
+      model=model
+      name=name)}}
 
-  {{yield (hash value=(or value (get model name))
-    controlClass=config.css.control
-    update=(action 'update')
-    setDirty=(action 'setDirty')
-    model=model
-    name=name)}}
+  {{else}}
+    {{#each options as |option|}}
+      <div class="radio">
+        <label>
+          {{one-way-radio
+            value    = (or value (get model name))
+            option   = option.key
+            name     = name
+            update   = (action "update")
+            focusOut = (action "setDirty")
+            disabled = disabled
+          }}
+          {{yield option}}
+        </label>
+      </div>
+    {{/each}}
+  {{/if}}
 
 {{else}}
   {{#if (eq type "select")}}

--- a/tests/integration/components/validated-form/component-test.js
+++ b/tests/integration/components/validated-form/component-test.js
@@ -29,6 +29,92 @@ test('it renders textareas', function(assert) {
   assert.equal(this.$('form textarea').length, 1);
 });
 
+test('it renders a radio group', function(assert) {
+  this.set('buttonGroupData', {
+    options: [
+      { key: '1', label: 'Option 1'},
+      { key: '2', label: 'Option 2'},
+      { key: '3', label: 'Option 3'},
+    ]
+  });
+
+  this.render(hbs`
+    {{#validated-form as |f|}}
+      {{f.input type='radioGroup' label='Options' name='testOptions' options=buttonGroupData.options}}
+    {{/validated-form}}
+  `);
+
+  assert.equal(this.$('input[type="radio"]').length, 3);
+  assert.equal(this.$('label').eq(0).text().trim(), 'Options');
+  assert.equal(this.$('label').eq(1).text().trim(), 'Option 1');
+  assert.equal(this.$('label').eq(2).text().trim(), 'Option 2');
+  assert.equal(this.$('label').eq(3).text().trim(), 'Option 3');
+});
+
+test('it renders a radio group with block form', function(assert) {
+  this.set('buttonGroupData', {
+    options: [
+      { key: '1', label: 'Option 1'},
+      { key: '2', label: 'Option 2'},
+      { key: '3', label: 'Option 3'},
+    ]
+  });
+
+  this.render(hbs`
+    {{#validated-form as |f|}}
+      {{#f.input type='radioGroup' label='Options' name='testOptions' options=buttonGroupData.options as |option|}}
+        {{option.label}} - block form
+      {{/f.input}}
+    {{/validated-form}}
+  `);
+
+  assert.equal(this.$('input[type="radio"]').length, 3);
+  assert.equal(this.$('label').eq(0).text().trim(), 'Options');
+  assert.equal(this.$('label').eq(1).text().trim(), 'Option 1 - block form');
+  assert.equal(this.$('label').eq(2).text().trim(), 'Option 2 - block form');
+  assert.equal(this.$('label').eq(3).text().trim(), 'Option 3 - block form');
+});
+
+test('it renders a radio group with block form and i18n support', function(assert) {
+  this.container.registry.registrations['helper:t'] = Ember.Helper.helper(function(arg){
+    const key = arg[0];
+    switch(key) {
+      case 'label.foo':
+        return 'Option One';        
+      case 'label.bar':
+        return 'Option Two';
+      case 'label.baz':
+        return 'Option Three';  
+      default:
+        return false;   
+    } 
+  });
+
+  this.set('buttonGroupData', {
+    options: [
+      { key: '1', label: 'label.foo'},
+      { key: '2', label: 'label.bar'},
+      { key: '3', label: 'label.baz'},
+    ]
+  });
+
+  this.render(hbs`
+    {{#validated-form as |f|}}
+      {{#f.input type='radioGroup' label='Options' name='testOptions' options=buttonGroupData.options as |option|}}
+        {{t option.label}} - block form
+      {{/f.input}}
+    {{/validated-form}}
+  `);
+
+  assert.equal(this.$('input[type="radio"]').length, 3);
+  assert.equal(this.$('label').eq(0).text().trim(), 'Options');
+  assert.equal(this.$('label').eq(1).text().trim(), 'Option One - block form');
+  assert.equal(this.$('label').eq(2).text().trim(), 'Option Two - block form');
+  assert.equal(this.$('label').eq(3).text().trim(), 'Option Three - block form');
+
+  this.container.registry.registrations['helper:t'] = null;
+});
+
 test('it renders submit buttons', function(assert) {
   this.on('stub', function() {});
 


### PR DESCRIPTION
Hi folks! 

Thanks for all your work on this package! It's lovely and usable.

I needed to use i18n-translated labels within radio groups. Instead of pre-translating them before creating the Options hash, I refactored the radio group to yield out for the label content of individual radios when used in block form.

This PR includes tests & some changes to the README to describe this usage.

Please let me know if you see spots for improvement, or if you have any questions? PS this is my work GitHub account, I'm at @jakemoves for other work.

Best regards,
Jacob