### PR TITLE
add ability to have a selectable prompt from the select dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The select element requires more options (see [{{one-way-select}}](https://githu
 - `optionLabelPath`
 - `optionValuePath`
 - `optionTargetPath`
-- `includeBlank`
+- `prompt`
 
 ```Handlebars
 {{f.input
@@ -192,7 +192,8 @@ The select element requires more options (see [{{one-way-select}}](https://githu
   label        = "Country"
   name         = "country"
   options      = countries
-  includeBlank = "Please choose..."
+  prompt = "Please choose..."
+  promptIsSelectable= = true
   }}
 ```
 

--- a/addon/templates/components/validated-input.hbs
+++ b/addon/templates/components/validated-input.hbs
@@ -44,13 +44,13 @@
     optionValuePath     = optionValuePath
     optionTargetPath    = optionTargetPath
     name                = name
-    class               = "form-control"
+    class               = config.css.control
     update              = (action "update")
     focusOut            = (action "setDirty")
-    prompt              = (if includeBlank (or includeBlank null))
+    prompt              = prompt
     disabled            = disabled
     multiple            = multiple
-    promptIsSelectable  = (if promptIsSelectable (or promptIsSelectable false))
+    promptIsSelectable  = promptIsSelectable
     }}
 
   {{else if (eq type "radioGroup")}}

--- a/addon/templates/components/validated-input.hbs
+++ b/addon/templates/components/validated-input.hbs
@@ -38,18 +38,19 @@
   {{#if (eq type "select")}}
 
     {{one-way-select
-      value            = (or value (get model name))
-      options          = options
-      optionLabelPath  = optionLabelPath
-      optionValuePath  = optionValuePath
-      optionTargetPath = optionTargetPath
-      name             = name
-      class            = config.css.control
-      update           = (action "update")
-      focusOut         = (action "setDirty")
-      includeBlank     = includeBlank
-      disabled         = disabled
-      multiple         = multiple
+    value               = (or value (get model name))
+    options             = options
+    optionLabelPath     = optionLabelPath
+    optionValuePath     = optionValuePath
+    optionTargetPath    = optionTargetPath
+    name                = name
+    class               = "form-control"
+    update              = (action "update")
+    focusOut            = (action "setDirty")
+    prompt              = (if includeBlank (or includeBlank null))
+    disabled            = disabled
+    multiple            = multiple
+    promptIsSelectable  = (if promptIsSelectable (or promptIsSelectable false))
     }}
 
   {{else if (eq type "radioGroup")}}


### PR DESCRIPTION
Allow for a selectable blank entry. 

This allows for a "select" to have a prompt ie> "Select a widget" and a validation of validatePresence(true).

I kept includeBlank to keep consistent with the documentation.