### PR TITLE
Separate validation errors from input field hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 
 Easily create forms with client side validations.
 
+## Financeit-specific details
+
+* changes should be made on feature branches named according to Financeit guidelines (i.e. `FIP-94592-fix-dropdowns`)
+* changes should be merged into `dev`
+* during development, Fit package.json files can be pointed to `dev` (i.e. `[URL]#dev`)
+* for production deployment:
+  * issue a semantically-versioned release off of `dev`
+  * Fit package.json files should be pointed to this specific release (i.e. `[URL]#v0.5.2`)
+* `master` should be kept in sync with upstream changes to the project, and used as a base for pull requests back to the project
+
 ## Demo
 
 ![gif](https://raw.githubusercontent.com/adfinis-sygroup/ember-validated-form/master/demo.gif)

--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ shapes: [{
 }],
 ```
 
+Optionally, you can pass a 'selected-key' parameter, which will add the 'selected' class defined in environment.js to that option's 'radio' element on render. (After initial render, your own closure action handlers will need to manage updating this.)
+
+```Handlebars
+{{f.input type="radioGroup" label="Shapes" name="shapes" options=shapes selected-key="s"}} 
+```
+
 If you want to customize the markup for each radio-button's label, you can invoke this component using block form. This is helpful if you need to localize your labels using something like [ember-i18n](https://github.com/jamesarosen/ember-i18n).
 
 ```Handlebars

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ Currently, the configuration supports
   - `control` (applied to form elements like `input`, `select`, ...)
   - `label`
   - `checkbox` (`div` wrapping checkboxes)
-  - `help` (`span` containing help texts and validation messages)
+  - `help` (`span` containing validation messages)
+  - `hint` (`p` containing form input hints. Always visible by default; to hide hints until their form inputs receive focus, provide the same class name here as for `help`) 
   - `button`
   - `submit` (Special styling for the submit button, overrides `button`)
   - `error` (Name of the class added to `group` when the element is invalid)

--- a/addon/components/validated-input/component.js
+++ b/addon/components/validated-input/component.js
@@ -20,6 +20,8 @@ export default Ember.Component.extend({
 
   type: 'input',
 
+  // hint (provided by caller)
+
   classNameBindings: ['dirty', 'config.css.group', 'validationClass'],
 
   validationClass: Ember.computed('showError', function() {

--- a/addon/components/validated-input/component.js
+++ b/addon/components/validated-input/component.js
@@ -41,7 +41,8 @@ export default Ember.Component.extend({
   }),
 
   firstError: Ember.computed('error', function() {
-    return this.get('error.validation')[0];
+    const errors = this.get('error.validation');
+    return Ember.isArray(errors) ? errors[0] : errors;
   }),
 
   showError: Ember.computed('isValid', 'dirty', 'submitted', function() {

--- a/addon/components/validated-input/template.hbs
+++ b/addon/components/validated-input/template.hbs
@@ -79,8 +79,8 @@
   {{/if}}
 {{/if}}
 
-{{#if help}}
-  <p class={{config.css.help}}>{{help}}</p>
+{{#if hint}}
+  <p class={{config.css.hint}}>{{hint}}</p>
 {{/if}}
 
 {{#if showError}}

--- a/addon/components/validated-input/template.hbs
+++ b/addon/components/validated-input/template.hbs
@@ -18,7 +18,7 @@
 
   {{else}}
     {{#each options as |option|}}
-      <div class="radio">
+      <div class="{{config.css.radio}} {{if (eq selected-key option.key) config.css.selected}}">
         <label>
           {{one-way-radio
             value    = (or value (get model name))
@@ -55,7 +55,7 @@
   {{else if (eq type "radioGroup")}}
 
     {{#each options as |option|}}
-      <div class="radio">
+      <div class="{{config.css.radio}} {{if (eq selected-key option.key) config.css.selected}}">
         <label>
           {{one-way-radio
             value    = (or value (get model name))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-validated-form",
-  "version": "0.3.1",
+  "version": "0.4.2",
   "description": "Easily create forms with client-side validations",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-validated-form",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Easily create forms with client-side validations",
   "keywords": [
     "ember-addon",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,7 @@ module.exports = function(environment) {
         control: 'form-control',
         label: 'control-label',
         help: 'help-block',
+        hint: 'hint',
         checkbox: 'checkbox',
         button: 'btn btn-default',
         submit: 'btn btn-primary'

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -19,7 +19,8 @@ module.exports = function(environment) {
         hint: 'hint',
         checkbox: 'checkbox',
         button: 'btn btn-default',
-        submit: 'btn btn-primary'
+        submit: 'btn btn-primary',
+        selected: 'selected'
       }
     },
     EmberENV: {

--- a/tests/integration/components/validated-form/component-test.js
+++ b/tests/integration/components/validated-form/component-test.js
@@ -73,6 +73,7 @@ test('it renders a radio group with block form', function(assert) {
   assert.equal(this.$('label').eq(1).text().trim(), 'Option 1 - block form');
   assert.equal(this.$('label').eq(2).text().trim(), 'Option 2 - block form');
   assert.equal(this.$('label').eq(3).text().trim(), 'Option 3 - block form');
+  assert.equal(this.$('.radio').hasClass('selected'), false);
 });
 
 test('it renders a radio group with block form and i18n support', function(assert) {
@@ -113,6 +114,30 @@ test('it renders a radio group with block form and i18n support', function(asser
   assert.equal(this.$('label').eq(3).text().trim(), 'Option Three - block form');
 
   this.container.registry.registrations['helper:t'] = null;
+});
+
+test('it renders a radio group with a selected-key passed in, where the option with that key is given the selected class on render', function(assert) {
+  this.set('buttonGroupData', {
+    options: [
+      { key: '1', label: 'Option 1'},
+      { key: '2', label: 'Option 2'},
+      { key: '3', label: 'Option 3'},
+    ],
+    selected: '2'
+  });
+
+  this.render(hbs`
+    {{#validated-form as |f|}}
+      {{#f.input type='radioGroup' label='Options' name='testOptions' options=buttonGroupData.options selected-key=buttonGroupData.selected as |option|}}
+        {{option.label}} - block form
+      {{/f.input}}
+    {{/validated-form}}
+  `);
+
+  assert.equal(this.$('.radio').length, 3);
+  assert.equal(this.$('.radio').eq(0).hasClass('selected'), false);
+  assert.equal(this.$('.radio').eq(1).hasClass('selected'), true);
+  assert.equal(this.$('.radio').eq(2).hasClass('selected'), false);
 });
 
 test('it renders submit buttons', function(assert) {

--- a/tests/integration/components/validated-form/component-test.js
+++ b/tests/integration/components/validated-form/component-test.js
@@ -45,6 +45,21 @@ test('it renders submit buttons', function(assert) {
   assert.equal(this.$('form button').text().trim(), 'Save!');
 });
 
+test('it renders a hint using a different class from the help block', function(assert){
+  /* this test depends on having 'help' and 'hint' set to different
+     class names in config/environment.js. I can't figure out how to
+     mock that file... */
+  this.render(hbs`
+    {{#validated-form as |f|}}
+      {{f.input label="First name" hint="Not your middle name!"}}
+    {{/validated-form}}
+  `);
+
+  assert.equal(this.$('.help-block').length, 0);
+  assert.equal(this.$('.hint').length, 1);
+  assert.equal(this.$('.hint').text().trim(), 'Not your middle name!');
+});
+
 test('does not render a <p> tag for buttons if no callbacks were passed', function(assert) {
   this.render(hbs`
     {{#validated-form as |f|}}


### PR DESCRIPTION
This PR allows for separate (and easier) styling of form hint text ('hint') and validation messages ('help'). 

There is a test, but I couldn't figure out how to mock the environment.js file...let me know what you think.