### PR TITLE
Fix "modified twice in a single render" issue

### DIFF
--- a/addon/templates/components/validated-input.hbs
+++ b/addon/templates/components/validated-input.hbs
@@ -50,7 +50,7 @@
       includeBlank        = includeBlank
       disabled            = disabled
       multiple            = multiple
-      promptIsSelectable  = promptIsSelectable
+      promptIsSelectable  = (or promptIsSelectable false)
     }}
 
   {{else if (eq type "radioGroup")}}


### PR DESCRIPTION
Without this fix we get an error when "promptIsSelectable" is not
specified and the submit button is pressed. This is due to the fact
that ember-one-way-select is updating "promptIsSelectable" inside
"didReceiveAttrs" to false when it's blank.

This issue should maybe be reported to ember-one-way-components, but I
didn't manage to create a small reproduction :(