### PR TITLE
Add blueprint which installs required dependencies

### DIFF
--- a/blueprints/ember-validated-form/index.js
+++ b/blueprints/ember-validated-form/index.js
@@ -6,6 +6,6 @@ module.exports = {
         { name: 'ember-changeset' },
         { name: 'ember-changeset-validations' }
       ]
-    })
+    });
   }
-}
+};

--- a/blueprints/ember-validated-form/index.js
+++ b/blueprints/ember-validated-form/index.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+module.exports = {
+  afterInstall() {
+    return this.addAddonsToProject({
+      packages: [
+        { name: 'ember-changeset' },
+        { name: 'ember-changeset-validations' }
+      ]
+    })
+  }
+}


### PR DESCRIPTION
Since ember-changeset and ember-changeset-validations must always be installed in the project to use this addon, we can install it with a blueprint to help the user.