### PR TITLE
Add a validateBeforeSubmit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ export default {
 | Name         | Type     | Description                                                                                                                                |
 | ----         | ----     | -----------                                                                                                                                |
 | model        | `Object` | ember-changeset containing the model that backs the form                                                                                   |
+| validateBeforeSubmit | `Boolean` | Specifies whether to run validations on inputs before the form has been submitted. Defaults to true. |
 | on-submit    | `Action`&#124;`Task` | Action or Task, that is triggered on form submit. The changeset is passed as a parameter. If specified, a submit button is rendered automatically. If a task is specified, the button will be disabled until it is finished (see example below). |
 
 When the submission of your form can take a little longer and your users are of the impatient kind, it is often necessary to disable the submit button to prevent the form from being submitted multiple times.
@@ -170,6 +171,7 @@ For a minimal demo see [this twiddle](https://ember-twiddle.com/3547207b06ed896f
 | disabled  | `Boolean` | Specifies if the input field is disabled. |
 | required  | `Boolean` | If true, a "*" is appended to the field's label indicating that it is required. |
 | value | `String` | Initial value of the form field. Default: model property defined by name. |
+| validateBeforeSubmit | `Boolean` | Specifies whether to run validations on this input before the form has been submitted. Defaults to the value set on the form. |
 | on-update | `Action` | Per default, the input elements are two-way-bound. If you want to implement custom update behavior, pass an action as `on-update`. The function receives two arguments: `update(value, changeset)`. |
 
 

--- a/addon/components/validated-form.js
+++ b/addon/components/validated-form.js
@@ -18,6 +18,8 @@ export default Component.extend({
 
   layout,
 
+  validateBeforeSubmit: true,
+
   init() {
     this._super(...arguments);
     if (this.get('model') && this.get('model').validate) {

--- a/addon/components/validated-input.js
+++ b/addon/components/validated-input.js
@@ -21,6 +21,8 @@ export default Component.extend({
 
   type: 'text',
 
+  validateBeforeSubmit: true,
+
   classNameBindings: ['dirty', 'config.css.group', 'validationClass'],
 
   inputId: computed('elementId', 'name', function() {
@@ -47,8 +49,16 @@ export default Component.extend({
     return this.get('error.validation')[0];
   }),
 
-  showError: computed('isValid', 'dirty', 'submitted', function() {
-    return !this.get('isValid') && (this.get('dirty') || this.get('submitted'));
+  showError: computed('isValid', 'validateBeforeSubmit', 'dirty', 'submitted', function() {
+    if (!this.get('isValid')) {
+      if (this.get('validateBeforeSubmit') && this.get('dirty')) {
+        return true;
+      }
+      if (this.get('submitted')) {
+        return true;
+      }
+    }
+    return false;
   }),
 
   requiredLabel: computed('config', function() {

--- a/addon/templates/components/validated-form.hbs
+++ b/addon/templates/components/validated-form.hbs
@@ -3,6 +3,7 @@
   input=(component 'validated-input'
     model=model
     submitted=submitted
+    validateBeforeSubmit=validateBeforeSubmit
     config=config
   )
   submit=(component 'validated-button'

--- a/tests/integration/components/validated-form-test.js
+++ b/tests/integration/components/validated-form-test.js
@@ -246,3 +246,48 @@ test('it performs basic validations on focus out', function(assert) {
   assert.equal(this.$('span.help-block').text(),
     'First name can\'t be blank');
 });
+
+test('it skips basic validations on focus out with validateBeforeSubmit=false set on the form', function(assert) {
+  this.on('submit', function() {});
+  this.set('UserValidations', UserValidations);
+
+  run(() => {
+    this.set('model', EmberObject.create({}));
+  });
+
+  this.render(hbs`
+    {{#validated-form
+      model=(changeset model UserValidations)
+      on-submit=(action "submit")
+      validateBeforeSubmit=false
+      as |f|}}
+      {{f.input label="First name" name="firstName"}}
+    {{/validated-form}}
+  `);
+  assert.equal(this.$('span.help-block').length, 0);
+  this.$('input').blur();
+
+  assert.equal(this.$('span.help-block').length, 0);
+});
+
+test('it skips basic validations on focus out with validateBeforeSubmit=false set on the input', function(assert) {
+  this.on('submit', function() {});
+  this.set('UserValidations', UserValidations);
+
+  run(() => {
+    this.set('model', EmberObject.create({}));
+  });
+
+  this.render(hbs`
+    {{#validated-form
+      model=(changeset model UserValidations)
+      on-submit=(action "submit")
+      as |f|}}
+      {{f.input label="First name" name="firstName" validateBeforeSubmit=false}}
+    {{/validated-form}}
+  `);
+  assert.equal(this.$('span.help-block').length, 0);
+  this.$('input').blur();
+
+  assert.equal(this.$('span.help-block').length, 0);
+});


### PR DESCRIPTION
Many form implementations don't run any validations until the first time the user tries to submit the form, so this option allows that behavior.