### PR TITLE
Update ember-truth-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-one-way-controls": "1.1.2",
-    "ember-truth-helpers": "1.2.0"
+    "ember-truth-helpers": "^2.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,21 +1937,20 @@ electron-to-chromium@^1.3.27:
   version "1.3.27"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
 
-ember-changeset-validations@1.X:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/ember-changeset-validations/-/ember-changeset-validations-1.2.9.tgz#cb275b8e4eb6f87a0332099f8e5996856f776f64"
+ember-changeset-validations@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/ember-changeset-validations/-/ember-changeset-validations-1.2.8.tgz#80c14fac5ee35dfff3538e6e9bc905c0686e193c"
   dependencies:
-    ember-changeset "1.4.1"
+    ember-changeset "1.3.0"
     ember-cli-babel "^6.0.0"
     ember-cli-htmlbars "^1.1.1"
     ember-validators "^1.0.0"
 
-ember-changeset@1.4.1, ember-changeset@1.X:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/ember-changeset/-/ember-changeset-1.4.1.tgz#e9a8f9c2bb3bfc1bc973c21a9e86a8cf8143df38"
+ember-changeset@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ember-changeset/-/ember-changeset-1.3.0.tgz#ae4cb06ae8add4550a46363263cd5958b522b9a6"
   dependencies:
-    ember-cli-babel "^6.8.2"
-    ember-deep-set "^0.1.2"
+    ember-cli-babel "^5.1.7"
 
 ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7, ember-cli-babel@^5.2.1:
   version "5.2.4"
@@ -2319,12 +2318,6 @@ ember-concurrency@0.7.19:
     ember-getowner-polyfill "^1.1.0"
     ember-maybe-import-regenerator "^0.1.4"
 
-ember-deep-set@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ember-deep-set/-/ember-deep-set-0.1.2.tgz#fde78d46a783d15d86687c5c7acc033f2dba6167"
-  dependencies:
-    ember-cli-babel "^5.1.7"
-
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
@@ -2457,11 +2450,11 @@ ember-test-helpers@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
 
-ember-truth-helpers@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.2.0.tgz#e63cffeaa8211882ae61a958816fded3790d065b"
+ember-truth-helpers@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-2.0.0.tgz#f3e2eef667859197f1328bb4f83b0b35b661c1ac"
   dependencies:
-    ember-cli-babel "^5.1.5"
+    ember-cli-babel "^6.8.2"
 
 ember-try-config@^2.0.1:
   version "2.2.0"


### PR DESCRIPTION
To silence a warning when running `yarn`: `warning ember-truth-helpers@1.2.0: The engine "ember-cli-app-version" appears to be invalid.`