### PR TITLE
Fix for removal from DOM during submit

### DIFF
--- a/addon/components/validated-form.js
+++ b/addon/components/validated-form.js
@@ -74,6 +74,11 @@ export default Component.extend({
     }
 
     model.validate().then(() => {
+      if (!this.element) {
+        // We were removed from the DOM while validating
+        return;
+      }
+
       if (model.get('isInvalid')) {
         return false;
       }
@@ -88,6 +93,10 @@ export default Component.extend({
 
     this.set('loading', true);
     runTaskOrAction(task, model).finally(() => {
+      if (!this.element) {
+        // We were removed from the DOM while running on-submit()
+        return;
+      }
       this.set('loading', false);
     });
   }

--- a/tests/integration/components/validated-form-test.js
+++ b/tests/integration/components/validated-form-test.js
@@ -400,3 +400,63 @@ test('it yields the loading state', function(assert) {
   run(() => deferred.resolve());
   assert.equal(this.$('span.loading').length, 0);
 });
+
+test('it handles being removed from the DOM during sync submit', function(assert) {
+  this.set('show', true);
+
+  this.on('submit', () => { this.set('show', false) });
+
+  run(() => {
+    this.set('model', EmberObject.create({}));
+  });
+
+  this.render(hbs`
+    {{#if show}}
+      {{#validated-form
+        model=(changeset model)
+        on-submit=(action "submit")
+        as |f|}}
+        {{#if f.loading}}
+          <span class="loading">loading...</span>
+        {{/if}}
+        {{f.submit}}
+      {{/validated-form}}
+    {{/if}}
+  `);
+
+  this.$('button').click();
+  assert.ok(true);
+});
+
+test('it handles being removed from the DOM during async submit', function(assert) {
+  this.set('show', true);
+  let deferred = defer();
+
+  this.on('submit', () => {
+    return deferred.promise.then(() => {
+      this.set('show', false);
+    })
+  });
+
+  run(() => {
+    this.set('model', EmberObject.create({}));
+  });
+
+  this.render(hbs`
+    {{#if show}}
+      {{#validated-form
+        model=(changeset model)
+        on-submit=(action "submit")
+        as |f|}}
+        {{#if f.loading}}
+          <span class="loading">loading...</span>
+        {{/if}}
+        {{f.submit}}
+      {{/validated-form}}
+    {{/if}}
+  `);
+
+  this.$('button').click();
+  run(() => deferred.resolve());
+  assert.ok(true);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,7 +2122,7 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.9.2:
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.8.1:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
   dependencies:
@@ -2139,7 +2139,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel@^6.10.0, ember-cli-babel@^6.3.0:
+ember-cli-babel@^6.10.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.2:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.11.0.tgz#79cb184bac3c05bfe181ddc306bac100ab1f9493"
   dependencies:
@@ -2477,10 +2477,10 @@ ember-disable-prototype-extensions@^1.1.2:
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
 
 ember-factory-for-polyfill@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.2.0.tgz#e27752a7d9dbd5336e8b470341bc1c55bbe3e4d2"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
   dependencies:
-    ember-cli-version-checker "^1.2.0"
+    ember-cli-version-checker "^2.1.0"
 
 ember-fork-me@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
If were form is removed from the DOM during the submit operation, it would throw a `cannot set property on destroyed object` when trying to clear the loading flag. Switching to an `ember-concurrency` task for the async behavior prevents those kinds of errors, and also allows for (in my opinion) more readable code.