### PR TITLE
Remove deprecated task support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,33 @@ export default {
 | validateBeforeSubmit | `Boolean` | Specifies whether to run validations on inputs before the form has been submitted. Defaults to true. |
 | on-submit    | `Action` | Action, that is triggered on form submit. The changeset is passed as a parameter. If the action returns a promise, then any rendered submit buttons will have a customizable CSS class added and the yielded `loading` template parameter will be set. |
 
-When the submission of your form can take a little longer and your users are of the impatient kind, it is often necessary to disable the submit button to prevent the form from being submitted multiple times. This can be done by using the `loading` template parameter and works very well with [ember-concurrency](http://ember-concurrency.com/) tasks.
+When the submission of your form can take a little longer and your users are of the impatient kind, it is often necessary to disable the submit button to prevent the form from being submitted multiple times. This can be done by using the `loading` template parameter:
+
+```javascript
+// controller
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  actions: {
+    submit(model) {
+      return model.save().then(() => {
+        // ... more code to show success messages etc.
+      });
+    }
+  }
+});
+```
+```Handlebars
+{{#validated-form
+  ...
+  on-submit = (action "submit")
+  as |f|}}
+  ...
+  {{f.submit label="Save" disabled=f.loading}}
+{{/validated-form}}
+```
+
+It also works very well with [ember-concurrency](http://ember-concurrency.com/) tasks:
 
 ```javascript
 // controller
@@ -159,7 +185,7 @@ export default Controller.extend({
 ```Handlebars
 {{#validated-form
   ...
-  on-submit = submit
+  on-submit = (perform submit)
   as |f|}}
   ...
   {{f.submit label="Save" disabled=f.loading}}

--- a/addon/components/validated-form.js
+++ b/addon/components/validated-form.js
@@ -2,19 +2,7 @@ import { resolve } from 'rsvp';
 import { computed } from '@ember/object';
 import { getOwner } from '@ember/application';
 import Component from '@ember/component';
-import { deprecate } from '@ember/application/deprecations';
 import layout from '../templates/components/validated-form';
-
-function runTaskOrAction(taskOrAction, model) {
-  deprecate("DEPRECATED passing a task to `on-submit` is deprecated. Please replace it with `on-submit=(perform myTask)`",
-    !taskOrAction.perform,
-    { until: '1.0.0', id: 'ember-validated-form-pass-task-to-on-submit' }
-  );
-
-  return taskOrAction.perform
-    ? taskOrAction.perform(model)
-    : resolve(taskOrAction(model));
-}
 
 export default Component.extend({
   tagName: 'form',
@@ -88,11 +76,11 @@ export default Component.extend({
   },
 
   runOnSubmit() {
-    const task = this.get('on-submit');
+    const onSubmit = this.get('on-submit');
     const model = this.get('model');
 
     this.set('loading', true);
-    runTaskOrAction(task, model).finally(() => {
+    resolve(onSubmit(model)).finally(() => {
       if (!this.element) {
         // We were removed from the DOM while running on-submit()
         return;

--- a/tests/integration/components/validated-form-test.js
+++ b/tests/integration/components/validated-form-test.js
@@ -5,7 +5,6 @@ import { helper } from '@ember/component/helper';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import UserValidations from 'dummy/validations/user';
-import { task } from 'ember-concurrency';
 
 moduleForComponent('validated-form', 'Integration | Component | validated form', {
   integration: true
@@ -295,34 +294,6 @@ test('it skips basic validations on focus out with validateBeforeSubmit=false se
   this.$('input').blur();
 
   assert.equal(this.$('span.help-block').length, 0);
-});
-
-test('on-submit can be an ember-concurrency task (deprecated)', function(assert) {
-  let deferred = defer();
-
-  this.set('submitTask', task(function * () {
-    yield deferred.promise;
-  }));
-
-  run(() => {
-    this.set('model', EmberObject.create({}));
-  });
-
-  this.render(hbs`
-    {{#validated-form
-      model=(changeset model)
-      on-submit=submitTask
-      as |f|}}
-      {{f.submit}}
-    {{/validated-form}}
-  `);
-  assert.notOk(this.$('button').hasClass('loading'))
-
-  this.$('button').click();
-  assert.ok(this.$('button').hasClass('loading'))
-
-  run(() => deferred.resolve());
-  assert.notOk(this.$('button').hasClass('loading'))
 });
 
 test('on-submit can be an action returning a promise', function(assert) {


### PR DESCRIPTION
Passing a task instance directly to on-submit is now no longer supported in favor of using the `perform` helper (`on-submit=(perform myTask)`).