### PR TITLE
On invalid submit

### DIFF
--- a/addon/components/validated-form.js
+++ b/addon/components/validated-form.js
@@ -69,9 +69,10 @@ export default Component.extend({
       }
 
       if (model.get("isInvalid")) {
-        return false;
+        this.runOnInvalidSubmit();
+      } else {
+        this.runOnSubmit();
       }
-      this.runOnSubmit();
     });
     return false;
   },
@@ -82,6 +83,24 @@ export default Component.extend({
 
     this.set("loading", true);
     resolve(onSubmit(model)).finally(() => {
+      if (!this.element) {
+        // We were removed from the DOM while running on-submit()
+        return;
+      }
+      this.set("loading", false);
+    });
+  },
+
+  runOnInvalidSubmit() {
+    const onInvalidSubmit = this.get("on-invalid-submit");
+    if (typeof onInvalidSubmit !== "function") {
+      return resolve(false);
+    }
+
+    const model = this.get("model");
+
+    this.set("loading", true);
+    resolve(onInvalidSubmit(model)).finally(() => {
       if (!this.element) {
         // We were removed from the DOM while running on-submit()
         return;

--- a/tests/dummy/app/templates/docs/components/validated-form.md
+++ b/tests/dummy/app/templates/docs/components/validated-form.md
@@ -16,10 +16,16 @@ submitted. Defaults to true.
 <br>
 **on-submit `<Action>`**
 <br>
-Action, that is triggered on form submit. The changeset is passed as a
-parameter. If the action returns a promise, then any rendered submit buttons
-will have a customizable CSS class added and the yielded `loading` template
-parameter will be set.
+Action, that is triggered on form submit if the changeset is valid. The
+changeset is passed as a parameter. If the action returns a promise, then any
+rendered submit buttons will have a customizable CSS class added and the yielded
+ `loading` template parameter will be set.
+<br>
+<br>
+**on-invalid-submit `<Action>`**
+<br>
+Action, that is triggered on form submit if the changset is invalid. The
+changeset is passed as a parameter. (Optional)
 <br>
 <br>
 **autocomplete `<String>`**

--- a/tests/integration/components/validated-form-test.js
+++ b/tests/integration/components/validated-form-test.js
@@ -355,6 +355,63 @@ test("it performs basic validations on submit", function(assert) {
   );
 });
 
+test("it calls on-invalid-submit after submit if changeset is invalid", function(assert) {
+  let invalidSubmitCalled;
+  this.on("invalidSubmit", function() {
+    invalidSubmitCalled = true;
+  });
+  this.set("UserValidations", UserValidations);
+
+  run(() => {
+    this.set(
+      "model",
+      EmberObject.create({
+        firstName: "x"
+      })
+    );
+  });
+
+  this.render(hbs`
+    {{#validated-form
+      model=(changeset model UserValidations)
+      on-invalid-submit=(action "invalidSubmit")
+      as |f|}}
+      {{f.input label="First name" name="firstName"}}
+      {{f.submit}}
+    {{/validated-form}}
+  `);
+  this.$("button").click();
+  assert.equal(invalidSubmitCalled, true);
+});
+
+test("it does not call on-invalid-submit after submit if changeset is valid", function(assert) {
+  let invalidSubmitCalled, submitCalled;
+  this.on("submit", function() {
+    submitCalled = true;
+  });
+  this.on("invalidSubmit", function() {
+    invalidSubmitCalled = true;
+  });
+
+  run(() => {
+    this.set("model", EmberObject.create({}));
+  });
+
+  this.render(hbs`
+    {{#validated-form
+      model=model
+      on-submit=(action "submit")
+      on-invalid-submit=(action "invalidSubmit")
+      as |f|}}
+      {{f.input label="First name" name="firstName"}}
+      {{f.submit}}
+    {{/validated-form}}
+  `);
+  this.$("button").click();
+  assert.notOk(invalidSubmitCalled);
+  assert.equal(submitCalled, true);
+});
+
 test("it performs basic validations on focus out", function(assert) {
   this.on("submit", function() {});
   this.set("UserValidations", UserValidations);


### PR DESCRIPTION
At the moment, when the user presses submit and the changeset is invalid, the component does not signal to the parent that anything happened.

Two use-cases (and the reason I created the PR):
- Show notification if form is invalid.
- Have a form with multiple pages: after an invalid submit, take the user to the page/view which contains the invalid input.