### PR TITLE
Update bootstrap 4 config error class

### DIFF
--- a/tests/dummy/app/snippets/config-bootstrap-v4.js
+++ b/tests/dummy/app/snippets/config-bootstrap-v4.js
@@ -17,7 +17,7 @@ const ENV = {
       submit: "btn btn-primary",
       loading: "loading",
       valid: "is-valid",
-      invalid: "is-invalid"
+      error: "is-invalid"
     }
   }
   // ...

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -26,7 +26,7 @@ module.exports = function(environment) {
         submit: "btn btn-primary",
         loading: "loading",
         valid: "is-valid",
-        invalid: "is-invalid"
+        error: "is-invalid"
       }
     },
     EmberENV: {


### PR DESCRIPTION
As I was setting up Bootstrap 4, I realized that the error class used in the component is `error`, not `invalid`. The rest of the documentation seems to have it right.

It's used here: https://github.com/adfinis-sygroup/ember-validated-form/blob/e4ee57279af6ff39c1d3e257cace01c8609fbcdc/addon/components/validated-input.js#L35