### PR TITLE
Yield the generated input id in block form

### DIFF
--- a/addon/templates/components/validated-input.hbs
+++ b/addon/templates/components/validated-input.hbs
@@ -13,7 +13,8 @@
       setDirty     = (action 'setDirty')
       model        = model
       class        = validationClass
-      name         = name)
+      name         = name
+      inputId      = inputId)
     }}
   {{else}}
     {{#each options as |option|}}

--- a/tests/integration/components/validated-input-test.js
+++ b/tests/integration/components/validated-input-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
-import { render } from "@ember/test-helpers";
+import { render, click } from "@ember/test-helpers";
 import hbs from "htmlbars-inline-precompile";
 import Changeset from "ember-changeset";
 
@@ -127,5 +127,146 @@ module("Integration | Component | validated input", function(hooks) {
     );
 
     assert.dom("input").hasAttribute("autocomplete", "new-password");
+  });
+
+  test("it renders the block if provided", async function(assert) {
+    await render(
+      hbs`
+        {{#validated-input as |fi|}}
+          <div id="custom-input"></div>
+        {{/validated-input}}
+      `
+    );
+
+    assert.dom("#custom-input").exists();
+  });
+
+  test("it yields the value provided to the block", async function(assert) {
+    await render(
+      hbs`
+        {{#validated-input value="my-value" as |fi|}}
+          <input value={{fi.value}} />
+        {{/validated-input}}
+      `
+    );
+
+    assert.dom("input").hasValue("my-value");
+  });
+
+  test("it yields the name from the model as value", async function(assert) {
+    this.set("model", new Changeset({ firstName: "Max" }));
+
+    await render(
+      hbs`
+        {{#validated-input model=model name="firstName" as |fi|}}
+          <input value={{fi.value}} />
+        {{/validated-input}}
+      `
+    );
+
+    assert.dom("input").hasValue("Max");
+  });
+
+  test("it yields the value as value if both model and value is provided", async function(assert) {
+    this.set("model", new Changeset({ firstName: "Max" }));
+
+    await render(
+      hbs`
+        {{#validated-input model=model name="firstName" value="Other Value" as |fi|}}
+          <input value={{fi.value}} />
+        {{/validated-input}}
+      `
+    );
+
+    assert.dom("input").hasValue("Other Value");
+  });
+
+  test("it yields the css control class as controlClass", async function(assert) {
+    this.set("config", {
+      css: {
+        control: "foobar"
+      }
+    });
+
+    await render(
+      hbs`
+        {{#validated-input config=config as |fi|}}
+          <input class="{{fi.controlClass}}" />
+        {{/validated-input}}
+      `
+    );
+
+    assert.dom("input").hasClass("foobar");
+  });
+
+  test("it yields the provided name", async function(assert) {
+    await render(
+      hbs`
+        {{#validated-input name="foobar" as |fi|}}
+          <input name={{fi.name}} />
+        {{/validated-input}}
+      `
+    );
+
+    assert.dom("input").hasAttribute("name", "foobar");
+  });
+
+  test("it yields the validation class as class", async function(assert) {
+    await render(
+      hbs`
+        {{#validated-input dirty=true as |fi|}}
+          <input class={{fi.class}} />
+        {{/validated-input}}
+      `
+    );
+
+    assert.dom("input").hasClass("valid");
+  });
+
+  test("it yields the model", async function(assert) {
+    this.set("model", new Changeset({ firstName: "Max" }));
+
+    await render(
+      hbs`
+        {{#validated-input model=model as |fi|}}
+          <input value={{fi.model.firstName}} />
+        {{/validated-input}}
+      `
+    );
+
+    assert.dom("input").hasValue("Max");
+  });
+
+  test("it yields an action for updating the model", async function(assert) {
+    let model = new Changeset({ firstName: "Max" });
+    this.set("model", model);
+
+    await render(
+      hbs`
+        {{#validated-input model=model name="firstName" as |fi|}}
+          <button onclick={{action fi.update "Merlin"}}></button>
+        {{/validated-input}}
+      `
+    );
+
+    await click("button");
+
+    assert.equal("Merlin", model.get("firstName"));
+  });
+
+  test("it yields an action marking the input as dirty", async function(assert) {
+    await render(
+      hbs`
+        {{#validated-input as |fi|}}
+          <button onclick={{action fi.setDirty}}></button>
+        {{/validated-input}}
+      `
+    );
+
+    assert.dom("div.dirty").doesNotExist();
+
+    await click("button");
+
+    assert.dom("div.dirty").exists();
   });
 });

--- a/tests/integration/components/validated-input-test.js
+++ b/tests/integration/components/validated-input-test.js
@@ -269,4 +269,18 @@ module("Integration | Component | validated input", function(hooks) {
 
     assert.dom("div.dirty").exists();
   });
+
+  test("it yields the input id to the block", async function(assert) {
+    await render(
+      hbs`
+        {{#validated-input label="Name" as |fi|}}
+          <input id={{fi.inputId}} />
+        {{/validated-input}}
+      `
+    );
+
+    let label = this.element.querySelector("label");
+    let input = this.element.querySelector("input");
+    assert.equal(label.getAttribute("for"), input.getAttribute("id"));
+  });
 });


### PR DESCRIPTION
This PR contains two changes in one:

1. Adds tests for the case when `validated-input` is used with a block
2. Passes the generated input id as part of the yielded hash

I can certainly split these up if that is desired, but I wanted to have no 1 while I was working on no 2 to make sure I didn't break anything. Reviewing the commits separately is probably a good idea.

### Passing the id is useful for using the generated label with a custom input
If you choose to provide a block to `validated-input` [as described in the documentation](https://adfinis-sygroup.github.io/ember-validated-form/latest/docs/components/validated-input#custom-input-elements), you can no longer use the generated label because the `for` attribute on that label doesn't point to your input. This means the user doesn't have the functionality of clicking the label to focus the input:

```hbs
{{#validated-form model=person as |f|}}
  {{f.input name="firstName" label="First Name" as |fi|}}
    <div class="my-custom-wrapper">
      <input
        type="text"
        name={{fi.name}}
        class="{{fi.class}} {{fi.controlClass}}"
        value={{fi.value}}
        oninput={{action fi.update value="target.value"}}
        onblur={{action fi.setDirty}}
      />
  {{/f.input}}
{{/validated-form}}
```

```html
<!-- Oh no, this label doesn't point at the input! -->
<label for="element52-input-firstName">First Name</label>
<div class="my-custom-wrapper">
  <input type="text" name="firstName" class="form-control" value="Max" />
</div>
```

With this change, you can now do that by setting the `id` on the input like this:

```diff
 {{#validated-form model=person as |f|}}
   {{f.input name="firstName" label="First Name" as |fi|}}
     <div class="my-custom-wrapper">
       <input
         type="text"
+        id={{fi.inputId}}
         name={{fi.name}}
         class="{{fi.class}} {{fi.controlClass}}"
         value={{fi.value}}
         oninput={{action fi.update value="target.value"}}
         onblur={{action fi.setDirty}}
       />
   {{/f.input}}
 {{/validated-form}}
```

```html
<label for="element52-input-firstName">First Name</label>
<div class="my-custom-wrapper">
  <input type="text" id="element52-input-firstName" name="firstName" class="form-control" value="Max"/>
</div>
```

Alternative ways to do this would be to not use `{{validated-input}}`, or to also provide a custom label component and generate my own `id`s for them.

Hopefully that's useful!