### PR TITLE
Show updated textarea data when underlying model changes

### DIFF
--- a/addon/templates/components/validated-input.hbs
+++ b/addon/templates/components/validated-input.hbs
@@ -102,7 +102,8 @@
       autocomplete= {{autocomplete}}
       oninput     = {{action "update" value = "target.value"}}
       onblur      = {{action "setDirty"}}
-      >{{_val}}</textarea>
+      value       = {{_val}}
+      ></textarea>
   {{else}}
     <input
       type        = {{type}}


### PR DESCRIPTION
Currently when changing the underlying model, the text shown in the textarea doesn't update.
This solves that.