### PR TITLE
fix(validated-input): use changeset.set if available to preserve state tracking on nested objects

### DIFF
--- a/addon/components/validated-input.js
+++ b/addon/components/validated-input.js
@@ -91,7 +91,9 @@ export class ValidatedInput extends Component {
     if (this["on-update"]) {
       this["on-update"](value, this.args.model);
     } else {
-      set(this.args.model, this.args.name, value);
+      this.args.model.set
+        ? this.args.model.set(this.args.name, value)
+        : set(this.args.model, this.args.name, value);
     }
   }
 }


### PR DESCRIPTION
This is a snippet which should have been in #581 but was forgotten :cry: 