### PR TITLE
fix(validated-input): interpret optionTargetPath on select

### DIFF
--- a/addon/components/validated-input/types/select.hbs
+++ b/addon/components/validated-input/types/select.hbs
@@ -21,13 +21,26 @@
       <optgroup label={{optionGroup.groupName}}>
         {{#each optionGroup.options as |opt|}}
           {{#let
-            (if @optionValuePath (get opt @optionValuePath) opt)
+            (if
+              (or @optionValuePath @optionTargetPath)
+              (get opt (or @optionValuePath @optionTargetPath))
+              opt
+            )
             as |optionValue|
           }}
             <option
               selected={{eq optionValue @value}}
               value={{optionValue}}
-            >{{if @optionLabelPath (get opt @optionLabelPath) opt}}</option>
+            >{{#if @optionLabelPath}}
+                {{get opt @optionLabelPath}}
+              {{else if @optionValuePath}}
+                {{get opt @optionValuePath}}
+              {{else if @optionTargetPath}}
+                {{get opt @optionTargetPath}}
+              {{else}}
+                {{opt}}
+              {{/if}}
+            </option>
           {{/let}}
         {{/each}}
       </optgroup>
@@ -35,14 +48,24 @@
   {{else}}
     {{#each @options as |opt|}}
       {{#let
-        (if @optionValuePath (get opt @optionValuePath) opt)
+        (if
+          (or @optionValuePath @optionTargetPath)
+          (get opt (or @optionValuePath @optionTargetPath))
+          opt
+        )
         as |optionValue|
       }}
-        <option selected={{eq optionValue @value}} value={{optionValue}}>{{if
+        <option selected={{eq optionValue @value}} value={{optionValue}}>{{#if
             @optionLabelPath
-            (get opt @optionLabelPath)
-            opt
-          }}</option>
+          }}
+            {{get opt @optionLabelPath}}
+          {{else if @optionValuePath}}
+            {{get opt @optionValuePath}}
+          {{else if @optionTargetPath}}
+            {{get opt @optionTargetPath}}
+          {{else}}
+            {{opt}}
+          {{/if}}</option>
       {{/let}}
     {{/each}}
   {{/if}}

--- a/addon/components/validated-input/types/select.js
+++ b/addon/components/validated-input/types/select.js
@@ -69,10 +69,45 @@ export default class SelectComponent extends Component {
     return groups;
   }
 
+  findOption(target) {
+    const targetPath = this.args.optionTargetPath;
+    const valuePath = this.args.optionValuePath || targetPath;
+    let options = this.args.options;
+
+    //flatten pre grouped options
+    if (this.hasPreGroupedOptions) {
+      options = options.flatMap((group) => group.options);
+    }
+
+    // multi select
+    if (this.args.multiple) {
+      const selectedValues = Array.prototype.filter
+        .call(target.options, (option) => option.selected)
+        .map((option) => option.value);
+
+      const foundOptions = options.filter((item) =>
+        selectedValues.includes(`${valuePath ? item[valuePath] : item}`)
+      );
+      if (targetPath) {
+        return foundOptions.map((item) => item[targetPath]);
+      }
+      return foundOptions;
+    }
+
+    //single select
+    const foundOption = options.find(
+      (item) => `${valuePath ? item[valuePath] : item.value}` === target.value
+    );
+    if (targetPath) {
+      return foundOption[targetPath];
+    }
+    return foundOption;
+  }
+
   @action
   onUpdate(event) {
     if (this.args.update) {
-      this.args.update(event.target.value);
+      this.args.update(this.findOption(event.target));
     }
   }
 

--- a/tests/integration/components/validated-input/types/select-test.js
+++ b/tests/integration/components/validated-input/types/select-test.js
@@ -23,6 +23,25 @@ module(
       assert.dom("option:first-child").hasProperty("selected", true);
     });
 
+    test("it works with solitary optionTargetPath property", async function (assert) {
+      assert.expect(2);
+      this.set("options", [
+        { key: 111, label: "firstOption" },
+        { key: 222, label: "secondOption" },
+      ]);
+
+      this.set("update", (value) => {
+        assert.strictEqual(value, 222);
+      });
+
+      await render(
+        hbs`<ValidatedInput::Types::Select @options={{this.options}} @update={{this.update}} @optionTargetPath="key" />`
+      );
+
+      assert.dom("option:first-child").hasText("111");
+      await select("select", "222");
+    });
+
     test("it renders option groups via groupLabelPath", async function (assert) {
       this.set("options", [
         { key: 1, label: 1, group: "one" },
@@ -111,15 +130,85 @@ module(
     });
 
     test("multiselect is working", async function (assert) {
+      assert.expect(3);
       this.set("options", ["1", "2"]);
+      this.set("update", (values) => {
+        assert.deepEqual(values, this.options);
+      });
 
       await render(
-        hbs`<ValidatedInput::Types::Select @options={{this.options}} @multiple={{true}} />`
+        hbs`<ValidatedInput::Types::Select @options={{this.options}} @multiple={{true}} @update={{this.update}} />`
       );
 
       await select("select", this.options);
       assert.dom("option:first-child").hasProperty("selected", true);
       assert.dom("option:last-child").hasProperty("selected", true);
+    });
+
+    test("multiselect works with pre grouped options", async function (assert) {
+      assert.expect(1);
+      this.set("update", (values) => {
+        assert.deepEqual(values, this.options[0].options);
+      });
+      this.set("options", [
+        {
+          groupName: "one",
+          options: [
+            { id: 1, label: "First", type: "group1" },
+            { id: 2, label: "Second", type: "group1" },
+          ],
+        },
+        {
+          groupName: "two",
+          options: [{ id: 3, label: "Third", type: "group2" }],
+        },
+      ]);
+
+      await render(
+        hbs`<ValidatedInput::Types::Select
+          @multiple={{true}}
+          @options={{this.options}}
+          @optionValuePath="id"
+          @optionLabelPath="label"
+          @update={{this.update}} />`
+      );
+
+      await select("select", ["1", "2"]);
+    });
+
+    test("multiselect works with pre grouped options and optionsTargetPath", async function (assert) {
+      assert.expect(1);
+      this.set("update", (values) => {
+        assert.deepEqual(
+          values,
+          this.options[0].options.map((val) => val.id)
+        );
+      });
+      this.set("options", [
+        {
+          groupName: "one",
+          options: [
+            { id: 1, label: "First", type: "group1" },
+            { id: 2, label: "Second", type: "group1" },
+          ],
+        },
+        {
+          groupName: "two",
+          options: [{ id: 3, label: "Third", type: "group2" }],
+        },
+      ]);
+
+      await render(
+        hbs`<ValidatedInput::Types::Select
+          @multiple={{true}}
+          @options={{this.options}}
+          @optionValuePath="id"
+          @optionTargetPath="id"
+          @optionLabelPath="label"
+          @update={{this.update}} />`
+      );
+
+      await select("select", ["1", "2"]);
     });
   }
 );


### PR DESCRIPTION
Fixes missing interpretation of public API `optionTargetPath` on select inputs.