### PR TITLE
chore(deprecation): fix deprecation when calling deprecate

### DIFF
--- a/addon/components/validated-input/types/select.js
+++ b/addon/components/validated-input/types/select.js
@@ -23,6 +23,7 @@ export default class SelectComponent extends Component {
           until: "6.0.0",
           since: "5.1.0",
           url: "https://github.com/adfinis-sygroup/ember-validated-form/releases/tag/v5.1.0",
+          for: "ember-validated-form",
         }
       );
     }


### PR DESCRIPTION
@derrabauke your deprecation message threw another deprecation message because the usage of `deprecate` without `for` is deprecated :rofl: 