### PR TITLE
chore(ember): drop support for Ember < 5.12 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-4.4
-          - ember-lts-4.8
-          - ember-lts-4.12
-          - ember-lts-5.4
-          - ember-lts-5.8
           - ember-lts-5.12
           - ember-lts-6.4
           - ember-release


### PR DESCRIPTION
Closes #1211

BREAKING CHANGE: This addon now only supports Ember.js versions from 5.12 upwards.