### PR TITLE
docs(config): fix documentation about `scrollErrorIntoView` feature

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -30,9 +30,7 @@ module.exports = function (defaults) {
     snippetPaths: ["tests/dummy/app/snippets"],
     "ember-validated-form": {
       theme: "bootstrap",
-      features: {
-        scrollErrorIntoView: false,
-      },
+      scrollErrorIntoView: false,
       defaults: {
         hint: "dummy/components/permanent-custom-hint",
       },

--- a/tests/dummy/app/snippets/config-features.js
+++ b/tests/dummy/app/snippets/config-features.js
@@ -1,9 +1,7 @@
 const app = new EmberAddon(defaults, {
   // ...
   "ember-validated-form": {
-    features: {
-      scrollErrorIntoView: true,
-    },
+    scrollErrorIntoView: true,
   },
   // ...
 });

--- a/tests/dummy/app/templates/docs/configuration.md
+++ b/tests/dummy/app/templates/docs/configuration.md
@@ -36,6 +36,6 @@ For instance:
 ## Other features
 
 If you want to scroll the first invalid field into view, you can set the
-`scrollErrorIntoView` property to `true` (default: false).
+`scrollErrorIntoView` property to `true` (default: `false`).
 
 <DocsSnippet @name='config-features.js' @title='ember-cli-build.js' />

--- a/tests/dummy/app/templates/docs/migration-v6.md
+++ b/tests/dummy/app/templates/docs/migration-v6.md
@@ -38,9 +38,7 @@ const app = new EmberAddon(defaults, {
   // ...
   "ember-validated-form": {
     theme: "bootstrap",
-    features: {
-      scrollErrorIntoView: true,
-    },
+    scrollErrorIntoView: true,
     defaults: {
       error: "myapp/components/some-component",
       // ...


### PR DESCRIPTION
The documentation about `scrollIntoView` mentioned it being nested in a `feature` object. However, the code does not use that nesting but expects the feature flag as root level key of the configuration.

https://github.com/adfinis/ember-validated-form/blob/b8d848a360e16aa7eaef05cdd1a0ecf1e7d3cc16/index.js#L11-L15
https://github.com/adfinis/ember-validated-form/blob/b8d848a360e16aa7eaef05cdd1a0ecf1e7d3cc16/index.js#L26-L28